### PR TITLE
 Makes progressive and line number dependant way width 

### DIFF
--- a/settings/post-process-display.sql
+++ b/settings/post-process-display.sql
@@ -5,6 +5,7 @@ SELECT
   max_diameter,
   number_of_routes,
   rels_osm_id,
+  ST_Length((ST_Dump(geom)).geom) AS length,
   (ST_Dump(geom)).geom AS geom
 FROM (
   SELECT

--- a/settings/trex.toml
+++ b/settings/trex.toml
@@ -32,10 +32,17 @@ SELECT *
 FROM d_stops_cluster
 WHERE geom && !bbox!
 ORDER BY max_avg_distance
-LIMIT 1000
+LIMIT 999
 """
 [[tileset.layer.query]]
 minzoom = 14
+sql="""
+SELECT *
+FROM d_stops
+WHERE geom && !bbox!
+ORDER BY number_of_routes
+LIMIT 999
+"""
 
 [[tileset.layer]]
 name = "stops_shield"
@@ -87,7 +94,24 @@ buffer_size = 2
 simplify = true
 query_limit = 1000
 [[tileset.layer.query]]
+minzoom = 11
+maxzoom = 12
+sql="""
+SELECT *
+FROM d_ways
+WHERE geom && !bbox! AND (max_diameter > 6000 OR number_of_routes > 1)
+ORDER BY length DESC
+LIMIT 999
+"""
+[[tileset.layer.query]]
 minzoom = 12
+sql="""
+SELECT *
+FROM d_ways
+WHERE geom && !bbox!
+ORDER BY length DESC
+LIMIT 999
+"""
 
 [[tileset.layer]]
 name = "routes_position"

--- a/web/vapour-style.json
+++ b/web/vapour-style.json
@@ -69,54 +69,67 @@
       }
     },
     {
-      "id": "ways-intercity",
+      "id": "ways",
       "type": "line",
       "metadata": {},
       "source": "vapour_trail",
       "source-layer": "ways",
-      "filter": [
-        "all",
-        [
-          ">",
-          "max_diameter",
-          3000
-        ]
-      ],
+      "minzoom": 11,
+      "maxzoom": 24,
       "layout": {
         "line-cap": "round",
         "line-join": "round"
       },
       "paint": {
         "line-color": "#4898ff",
-        "line-width": 2
-      }
-    },
-    {
-      "id": "ways-urban",
-      "type": "line",
-      "metadata": {},
-      "source": "vapour_trail",
-      "source-layer": "ways",
-      "minzoom": 12,
-      "filter": [
-        "any",
-        [
-          "<=",
-          "max_diameter",
-          3000
-        ],
-        [
-          "!has",
-          "max_diameter"
+        "line-width": [
+          "interpolate",
+          [
+            "linear"
+          ],
+          [
+            "zoom"
+          ],
+          11,
+          [
+            "min",
+            [
+              "-",
+              [
+                "get",
+                "number_of_routes"
+              ],
+              1.5
+            ],
+            0.5
+          ],
+          12,
+          [
+            "min",
+            [
+              "-",
+              [
+                "get",
+                "number_of_routes"
+              ],
+              0.5
+            ],
+            0.5
+          ],
+          14,
+          [
+            "min",
+            [
+              "+",
+              [
+                "get",
+                "number_of_routes"
+              ],
+              0.5
+            ],
+            4
+          ]
         ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
-      "paint": {
-        "line-color": "#4898ff",
-        "line-width": 2
       }
     },
     {


### PR DESCRIPTION
Build on top of #17

- Makes tiles content dependent of zoom, order content to better display when hit limit
- Uses only one layer for ways on style
- Makes width depending on zoom and of the number of route using this way

![image](https://user-images.githubusercontent.com/1785486/40021271-a2e9573e-57c4-11e8-9365-8eb446d4b019.png)

![image](https://user-images.githubusercontent.com/1785486/40021275-a6084bfa-57c4-11e8-9357-8ef9814c8fc8.png)
