### PR TITLE
T rex 0.9

### DIFF
--- a/scripts/generate_all_tiles.sh
+++ b/scripts/generate_all_tiles.sh
@@ -12,4 +12,4 @@ set -o pipefail
 set -o nounset
 #set -x
 
-docker-compose run --rm --entrypoint "t_rex generate --config /config/config.toml --overwrite true --extent=${bbox} --maxzoom 16 --minzoom 0" t-rex
+docker-compose run --rm --entrypoint "t_rex generate --config /config/config.toml --overwrite true --extent=${bbox} --maxzoom 16 --minzoom 6" t-rex

--- a/settings/trex.toml
+++ b/settings/trex.toml
@@ -13,6 +13,11 @@ predefined = "web_mercator"
 
 [[tileset]]
 name = "vapour_trail"
+attribution = "<a href='http://junglebus.io/'>Jungle Bus</a> <a href='http://www.openstreetmap.org/copyright'>© OpenStreetMap contributors</a>"
+minzoom = 6
+#maxzoom = 22
+#center = 0, 0 # longitude, latitude
+start_zoom = 10
 
 [[tileset.layer]]
 name = "stops"

--- a/settings/trex.toml
+++ b/settings/trex.toml
@@ -14,8 +14,6 @@ predefined = "web_mercator"
 [[tileset]]
 name = "vapour_trail"
 attribution = "<a href='http://junglebus.io/'>Jungle Bus</a> <a href='http://www.openstreetmap.org/copyright'>© OpenStreetMap contributors</a>"
-minzoom = 6
-#maxzoom = 22
 #center = 0, 0 # longitude, latitude
 start_zoom = 10
 

--- a/web/layers.js
+++ b/web/layers.js
@@ -10,9 +10,6 @@ map.on('load', function() {
                     map.addSource(source, json.sources[source]);
                 }
 
-                // that's a little hack to add the attribution, that is not set in the t-rex tilejson
-                // "attribution": "Jungle Bus"
-
                 for (var i = 0; i < json.layers.length; i++) {
                     if (json.layers[i].type != 'background') {
                         map.addLayer(json.layers[i]);


### PR DESCRIPTION
Fix #12 with new t-rex version (attribution)
Setup min zoom for tiles. So the mapbox gl client do not ask for tiles to the server zoom level that does not have dato to provide.