### PR TITLE
Display a proper osm_id in api and tiles

### DIFF
--- a/settings/post-process-display.sql
+++ b/settings/post-process-display.sql
@@ -166,6 +166,20 @@ GROUP BY
 ;
 ALTER TABLE d_routes_position DROP COLUMN rels_osm_id;
 
+-- Stop positions by route
+DROP TABLE IF EXISTS d_route_stop_positions;
+CREATE TABLE d_route_stop_positions AS
+SELECT DISTINCT
+  rel_osm_id as route_osm_id,
+  pos,
+  geom
+FROM (
+  SELECT rel_osm_id, unnest(positions_ids) as pos
+  FROM d_routes_position_ids
+) t
+INNER JOIN d_routes_position
+  on t.pos = d_routes_position.id
+ORDER BY pos;
 
 -- Add bus routes info on bus stops
 DROP TABLE IF EXISTS d_stops;

--- a/settings/post-process-internal.sql
+++ b/settings/post-process-internal.sql
@@ -1,3 +1,10 @@
+-- fix route ids modified by imposm
+UPDATE osm_relations_route
+SET osm_id = ABS(osm_id);
+
+UPDATE osm_relation_members_route
+SET rel_osm_id = ABS(rel_osm_id);
+
 -- Build routes meta data
 DROP TABLE IF EXISTS i_routes;
 CREATE TABLE i_routes AS

--- a/vapour_api/api.py
+++ b/vapour_api/api.py
@@ -65,13 +65,8 @@ def get_route_stop_positions(route_id):
                 st_asGeoJSON(ST_Transform(geom, 4326)) as geojson, 
                 st_X(ST_Transform(geom, 4326)) as lon,
                 st_Y(ST_Transform(geom, 4326)) as lat
-            FROM (
-                SELECT rel_osm_id, unnest(positions_ids) as pos
-                FROM d_routes_position_ids
-            ) t 
-            INNER JOIN d_routes_position 
-                on t.pos = d_routes_position.id
-            WHERE rel_osm_id = :route_id
+            FROM d_route_stop_positions
+            WHERE route_osm_id = :route_id
             ORDER BY pos
         """
         ),


### PR DESCRIPTION
imposm adds a `-` to all relation ids. This PR aims to remove it from routes ids in the API and for Ids in t-rex tiles.