### PR TITLE
externalise a first web component

### DIFF
--- a/web/index.css
+++ b/web/index.css
@@ -55,13 +55,6 @@ header {
     }
 }
 
-.bus_box {
-    border-bottom-width: 4px;
-    border-bottom-style: solid;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
-}
-
 .bus_box_div {
     margin-bottom: 10px;
 }

--- a/web/index.html
+++ b/web/index.html
@@ -4,6 +4,7 @@
         <meta charset='utf-8'/>
         <title>VapourTrail</title>
         <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no'/>
+        <script src="https://unpkg.com/jungle_bus_web_components@1.0.0/src/transport_thumbnail.js"></script>
         <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.45.0/mapbox-gl.js'></script>
         <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.45.0/mapbox-gl.css' rel='stylesheet'/>
         <link href='index.css' rel='stylesheet'/>

--- a/web/index.js
+++ b/web/index.js
@@ -105,15 +105,15 @@ map.on('load', function() {
 
                 for (const route of stop_data.properties.routes_at_stop) {
                     const route_id = route['route_osm_id'];
-                    html += `<div class='bus_box_div'>
-                                <span class='bus_box' style='border-bottom-color: ${route['colour'] || "grey"};' >
-                                    [${route['network'] || '??'}]
-                                    <span>🚍</span>
-                                    <span>${route['ref'] || '??'}</span>
-                                </span>
-                              : ${route['destination'] || '??'}
-                              <a href='#' onclick='filter_on_one_route(${route_id});map.flyTo({center:[${stop_data.geometry.coordinates}]})'>Voir la ligne</a> </br>
-                            </div>`;
+                    html += `<transport-thumbnail
+                        data-transport-network="${route['network'] || '??'}"
+                        data-transport-mode="bus"
+                        data-transport-line-code="${route['ref'] || '??'}"
+                        data-transport-line-color="${route['colour'] || "grey"}"
+                        data-transport-destination="${route['destination'] || '??'}">
+                    </transport-thumbnail>
+                    <a href='#' onclick='filter_on_one_route(${route_id});map.flyTo({center:[${stop_data.geometry.coordinates}]})'>Voir la ligne</a> </br>
+                    `
                 }
 
                 html += `<div class="osm_attribution">${create_osm_attribution_for_the_stop(stop_data.properties.osm_id, stop_data.properties.osm_type)}</div>`
@@ -201,10 +201,11 @@ function create_osm_attribution(osm_object_id, osm_type, object_designation) {
 
 function create_route_medata(route_info) {
     var inner_html = `<div class='bus_box_div'>
-                <span class='bus_box' style='border-bottom-color: ${route_info['colour'] || "grey"};' >
-                    <span>🚍</span>
-                    <span>${route_info['ref'] || '??'}</span>
-                </span>
+                <transport-thumbnail
+                    data-transport-mode="bus"
+                    data-transport-line-code="${route_info['ref'] || '??'}"
+                    data-transport-line-color="${route_info['colour'] || "grey"}">
+                </transport-thumbnail>
                 &nbsp; ${route_info['name']}
             </div>`;
     inner_html += `De <b>${route_info['origin'] || '??'}</b> vers <b>${route_info['destination'] || '??'}</b>`;
@@ -237,12 +238,11 @@ function create_stop_list_for_a_route(stop_list, route_colour) {
           `
         for (const shield of stop['shields']) {
             inner_html += `
-                <div class='bus_box_inline_div'>
-                  <span class='bus_box' style='border-bottom-color: ${shield['colour'] || "grey"};' >
-                    <span>🚍</span>
-                  <span>${shield['ref'] || '??'}</span>
-                  </span>
-                </div>
+                <transport-thumbnail class="bus_box_inline_div"
+                    data-transport-mode="bus"
+                    data-transport-line-code="${shield['ref'] || '??'}"
+                    data-transport-line-color="${shield['colour'] || "grey"}">
+                </transport-thumbnail>
                 `
         }
         inner_html += `


### PR DESCRIPTION
This PR does not change anything in VapourTrail.

I've created a web component to display the metadata of a transport route or line :
![](https://github.com/Jungle-Bus/transport_web_components/raw/master/demo/Screenshot_transport-thumbnail.png)

The purpose is to unify the UI between Jungle Bus projects. 
The source code of this first component can be found here: https://github.com/Jungle-Bus/transport_web_components
It is already in use in Bifidus and ref-lignes-stif.